### PR TITLE
Backup website when deploying manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Backup existing version of website
         # Only backup on push to master
-        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ success() && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) && github.ref == 'refs/heads/master' }}
         run: |
           mkdir backup
           sudo apt-get install -y ncftp


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

This is a bug fix.
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This PR enables the backing up of the currently deployed version of the website before pushing a new one, when the  build/deploy workflow is triggered manually

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

PR #2 enabled deploying the website manually by triggering the build/deploy workflow manually on the master branch via workflow_dispatch. This PR enables the same functionality, but for the backup step of the workflow.